### PR TITLE
attention_result must become a df before calling the EpistasisFinder function

### DIFF
--- a/Epistasis_pipeline.ipynb
+++ b/Epistasis_pipeline.ipynb
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "1c81bdd3-3adf-4ebe-a37e-95287eb5346c",
    "metadata": {
     "pycharm": {
@@ -83,7 +83,8 @@
    },
    "outputs": [],
    "source": [
-    "attention_result = 'path_to_attention_result_from_your_G2PT_prediction'"
+    "attention_result = 'path_to_attention_result_from_your_G2PT_prediction'\n",
+    "attention_result = pd.read_csv(attention_result)"
    ]
   },
   {


### PR DESCRIPTION
Just a minor tweak to [epistais_pipeline.ipynb](https://github.com/idekerlab/G2PT/blob/3cb24385b500fea6fa30758dcabbd2e487dc2aa6/Epistasis_pipeline.ipynb) to make sure the workflow runs smoothly and as expected.